### PR TITLE
Fix test breakage after Drupal 8.4 upgrade

### DIFF
--- a/src/AnonymousContext.php
+++ b/src/AnonymousContext.php
@@ -439,6 +439,7 @@ class AnonymousContext extends MinkContext implements Context, SnippetAcceptingC
 
     /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
     $entity = $this->entities[$entity_type][$index];
+    $entityTypeManager->getViewBuilder($entity_type)->resetCache();
     $this->visitPath($entity->toUrl()->toString());
   }
 


### PR DESCRIPTION
An update to Drupal core from 8.3 to 8.4 started to see tests fail unless the following line was added:

`Given/And I am logged in as an administrator`

This suggested caching issues and the line introduced here sees the tests to pass again.